### PR TITLE
Add Codex agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Clients (Phone / Laptop / Orchestrator)
   # macOS
   brew install tmux
   ```
-- **opencode**, **Claude Code**, or **Copilot** CLI installed and authenticated
+- **opencode**, **Claude Code**, **Copilot**, or **Codex** CLI installed and authenticated
 
 ## Installation
 
@@ -185,6 +185,7 @@ fleet start --name api --project /path/to/api
 # Start with a specific agent (default: opencode)
 fleet start --name api --project /path/to/api --agent claude-code
 fleet start --name ml --project /path/to/ml --agent copilot
+fleet start --name docs --project /path/to/docs --agent codex
 
 # Start multiple sessions in batch (detached mode)
 fleet start --name api --project /path/to/api -d
@@ -197,7 +198,7 @@ fleet attach api
 
 ### From the Web UI
 
-Click **+ New Session** in the dashboard header. Select the agent (opencode, Claude Code, or copilot), enter the project path (absolute path on the server), and optionally a session name (defaults to the directory name). The session launches detached — use the dashboard to monitor and interact.
+Click **+ New Session** in the dashboard header. Select the agent (opencode, Claude Code, Copilot, or Codex), enter the project path (absolute path on the server), and optionally a session name (defaults to the directory name). The session launches detached — use the dashboard to monitor and interact.
 
 For **OpenCode web UI** sessions, Fleet starts and proxies the workspace automatically by default. Project path is required; URL and port are only for advanced/manual attachment cases.
 
@@ -225,7 +226,7 @@ Forking requires the source session to have reported its session ID (happens aut
 ### CLI Commands
 
 ```bash
-fleet start --name <name> --project <path> [--agent opencode|claude-code|copilot] # Start a session
+fleet start --name <name> --project <path> [--agent opencode|claude-code|copilot|codex] # Start a session
 fleet start --name <name> --project <path> -d # Start detached
 fleet list                                    # List sessions
 fleet attach <name>                           # Attach to tmux
@@ -236,10 +237,10 @@ fleet stop <name>                             # Stop session + cleanup
 `fleet start` will:
 1. Create a tmux session `fleet-<name>`
 2. Register the MCP server with the agent (if not already registered)
-3. Launch the agent with fleet instructions via `--prompt`
+3. Launch the agent with fleet instructions as the initial prompt
 4. Attach to the session (unless `-d` is passed)
 
-Supported agents: `opencode` (default), `claude-code`, `copilot`. Only `claude-code` sessions can be forked.
+Supported agents: `opencode` (default), `claude-code`, `copilot`, `codex`. Only `claude-code` sessions can be forked.
 
 Fleet instructions are injected as a system prompt at launch time — no modifications to the project's `CLAUDE.md` are needed.
 

--- a/fleet_manager/cli.py
+++ b/fleet_manager/cli.py
@@ -121,7 +121,7 @@ def main() -> None:
     start_p = sub.add_parser("start", help="Start a new fleet-managed agent session")
     start_p.add_argument("--name", required=True, help="Session name")
     start_p.add_argument("--project", default=".", help="Project directory")
-    start_p.add_argument("--agent", default="opencode", choices=["opencode", "claude-code", "copilot"],
+    start_p.add_argument("--agent", default="opencode", choices=["opencode", "claude-code", "copilot", "codex"],
                          help="Agent to launch (default: opencode)")
     start_p.add_argument("--port", type=int, default=7700, help="Fleet manager port")
     start_p.add_argument("-d", "--detach", action="store_true",

--- a/fleet_manager/session_launcher.py
+++ b/fleet_manager/session_launcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shlex
 import signal
 import socket
 import subprocess
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 TMUX_PREFIX = "fleet-"
 WEB_HOST = "127.0.0.1"
-USER_BIN_PATHS = ("~/.opencode/bin", "~/.local/bin")
+USER_BIN_PATHS = ("~/.opencode/bin", "~/.npm-global/bin", "~/.local/bin")
 
 
 class LaunchError(Exception):
@@ -76,13 +77,13 @@ async def start_session(
     """Start a new fleet-managed agent session.
 
     Validates inputs, creates tmux session, registers MCP, launches agent.
-    Supports agents: "claude-code", "opencode", "copilot"
+    Supports agents: "claude-code", "opencode", "copilot", "codex"
     Returns the created session dict.
 
     Raises LaunchError on validation failures.
     """
     # Validate agent
-    valid_agents = ["claude-code", "opencode", "copilot"]
+    valid_agents = ["claude-code", "opencode", "copilot", "codex"]
     if agent not in valid_agents:
         raise LaunchError(f"Unknown agent '{agent}'. Valid options: {', '.join(valid_agents)}")
 
@@ -147,6 +148,10 @@ async def start_session(
         config_content = json.dumps({"mcp": mcp_config}, indent=2)
         config_check = f"if [ ! -f {project}/.copilot.json ]; then\n"
         config_write = f"  cat > {project}/.copilot.json << 'COPILOT_EOF'\n{config_content}\nCOPILOT_EOF\n"
+    elif agent == "codex":
+        agent_cmd = "codex"
+        config_check = ""
+        config_write = ""
     else:  # claude-code
         agent_cmd = "claude"
         config_file = f"{project}/.claude.json"
@@ -158,15 +163,26 @@ async def start_session(
     script_file = f"/tmp/fleet-launch-{name}.sh"
     with open(script_file, "w") as f:
         f.write(f'#!/bin/bash\n')
-        f.write(f'export PATH="$HOME/.opencode/bin:$HOME/.local/bin:$PATH"\n')
-        f.write(config_check)
-        f.write(config_write)
-        f.write(f'fi\n')
+        f.write(f'export PATH="$HOME/.opencode/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"\n')
+        if config_check:
+            f.write(config_check)
+            f.write(config_write)
+            f.write(f'fi\n')
+        if agent == "codex" and auth_token:
+            f.write(f'export FLEET_AUTH_TOKEN={shlex.quote(auth_token)}\n')
         f.write(f'sleep 1\n')
         f.write(f'cd {project} && FLEET_SESSION_ID={name} exec {agent_cmd} ')
         if agent == "copilot":
             # Use heredoc to avoid shell quoting issues
             f.write(f'-i "$(cat <<\'FLEET_PROMPT_EOF\'\n')
+            f.write(fleet_prompt)
+            f.write(f'\nFLEET_PROMPT_EOF\n')
+            f.write(f')"\n')
+        elif agent == "codex":
+            f.write(f"-c {shlex.quote(f'mcp_servers.fleet-manager.url={json.dumps(mcp_url)}')} ")
+            if auth_token:
+                f.write("-c " + shlex.quote("mcp_servers.fleet-manager.bearer_token_env_var=\"FLEET_AUTH_TOKEN\"") + " ")
+            f.write(f'"$(cat <<\'FLEET_PROMPT_EOF\'\n')
             f.write(fleet_prompt)
             f.write(f'\nFLEET_PROMPT_EOF\n')
             f.write(f')"\n')
@@ -268,7 +284,7 @@ async def fork_session(
     tmux_target = f"={TMUX_PREFIX}{new_name}:0"
     with open(script_file, "w") as f:
         f.write(f'#!/bin/bash\n')
-        f.write(f'export PATH="$HOME/.opencode/bin:$HOME/.local/bin:$PATH"\n')
+        f.write(f'export PATH="$HOME/.opencode/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"\n')
         f.write(f'# Create .claude.json with MCP config only if not exists\n')
         f.write(f'if [ ! -f {project}/.claude.json ]; then\n')
         f.write(f'  cat > {project}/.claude.json << \'CLAUDE_EOF\'\n')

--- a/web/index.html
+++ b/web/index.html
@@ -314,6 +314,7 @@
           <option value="opencode">OpenCode</option>
           <option value="claude-code">Claude Code</option>
           <option value="copilot">Copilot</option>
+          <option value="codex">Codex</option>
         </select>
         </div>
         <label class="form-label" for="ns-project">Project path</label>
@@ -362,6 +363,7 @@
           <option value="opencode">OpenCode</option>
           <option value="claude-code">Claude Code</option>
           <option value="copilot">Copilot</option>
+          <option value="codex">Codex</option>
         </select>
 
         <div class="modal-actions">


### PR DESCRIPTION
## Issue
Codex sessions could be selected only after code changes, but Fleet did not treat Codex as a supported regular agent and the launcher PATH did not include the npm-global install location.

## Fix
- Add codex to CLI and launcher supported-agent lists.
- Add Codex to the New Session and default-agent UI dropdowns.
- Launch Codex with Fleet MCP config via CLI config overrides and pass Fleet auth through an environment variable.
- Include ~/.npm-global/bin in generated launcher PATHs so the Codex executable can be found.
- Update README examples and supported-agent documentation.

## Verification
- bash scripts/check-js.sh
- python -m compileall fleet_manager
- python -m fleet_manager.cli start --help
- launcher-style PATH resolves codex-cli 0.134.0

Note: pytest is not installed in this environment.