### PR TITLE
Improve OpenCode workspace handling

### DIFF
--- a/fleet_manager/server.py
+++ b/fleet_manager/server.py
@@ -496,12 +496,20 @@ async def workspace_proxy(request: Request, session_id: str, path: str = ""):
     content_type = upstream.headers.get("content-type", "")
     if _is_event_stream(content_type):
         async def stream_body():
-            async for chunk in upstream.aiter_bytes():
-                yield chunk
+            try:
+                async for chunk in upstream.aiter_bytes():
+                    yield chunk
+            except asyncio.CancelledError:
+                raise
+            except httpx.HTTPError as exc:
+                logger.info("Workspace event stream ended for %s (%s): %s", session_id, upstream_path, exc)
 
         async def close_stream() -> None:
             await upstream.aclose()
             await client.aclose()
+
+        response_headers.setdefault("cache-control", "no-cache")
+        response_headers.setdefault("x-accel-buffering", "no")
 
         return StreamingResponse(
             stream_body(),

--- a/web/app.js
+++ b/web/app.js
@@ -1238,6 +1238,22 @@ function openWorkspaceInNewTab(sessionId) {
   if (url) window.open(url, '_blank', 'noopener,noreferrer');
 }
 
+async function closeWorkspaceSession(sessionId, statusElId) {
+  if (!sessionId) return;
+  if (!confirm(`Close workspace "${sessionId}"? Fleet will stop the managed OpenCode web server if it started one.`)) return;
+  try {
+    await api(`/api/sessions/${sessionId}`, { method: 'DELETE' });
+    clearSessionHistory(sessionId);
+    if (focusSessionId === sessionId) closeFocus();
+    if (currentSessionId === sessionId) showDashboard();
+    if (activeTabSessionId === sessionId) activeTabSessionId = null;
+    showStatusMsg(statusElId, `Closed ${sessionId}`, 'success');
+    await refreshDashboard();
+  } catch (e) {
+    showStatusMsg(statusElId, `Failed: ${e.message}`, 'error');
+  }
+}
+
 function getWorkspaceStatusElementId(containerId) {
   if (containerId === 'tab-workspace') return 'tab-msg-status';
   if (containerId === 'sidetab-workspace') return 'sidetab-msg-status';
@@ -1270,6 +1286,7 @@ function renderWorkspace(session, containerId) {
            <button class="btn-sm workspace-action-btn" title="Reload workspace" onclick="reloadWorkspaceSession('${esc(session.session_id).replace(/'/g, "\\'")}','${statusElId}')"><span class="workspace-action-icon">↻</span><span class="workspace-action-label">Reload</span></button>
            <button class="btn-sm workspace-action-btn" title="Restart workspace" onclick="restartWorkspaceSession('${esc(session.session_id).replace(/'/g, "\\'")}','${statusElId}')"><span class="workspace-action-icon">⟲</span><span class="workspace-action-label">Restart</span></button>
            <button class="btn-sm workspace-action-btn" title="Open workspace in new tab" onclick="openWorkspaceInNewTab('${esc(session.session_id).replace(/'/g, "\\'")}')"><span class="workspace-action-icon">↗</span><span class="workspace-action-label">Open</span></button>
+           <button class="btn-sm btn-danger workspace-action-btn" title="Close workspace" onclick="closeWorkspaceSession('${esc(session.session_id).replace(/'/g, "\\'")}','${statusElId}')"><span class="workspace-action-icon">×</span><span class="workspace-action-label">Close</span></button>
          </div>
        </div>
        <div class="workspace-frame-wrap">


### PR DESCRIPTION
## Issue
OpenCode web UI workspaces can leave broken event-stream requests in the browser when the upstream stream ends unexpectedly, and workspace toolbar actions lack a direct Close control.

## Fix
- Catch upstream httpx event-stream errors in the workspace proxy so Fleet can end the browser stream cleanly.
- Add no-cache and no-buffering headers for proxied event streams.
- Add a Close button to workspace toolbars that calls the existing session DELETE endpoint, clears local session history, updates active views, and refreshes the dashboard.

## Verification
- bash scripts/check-js.sh
- python -m compileall fleet_manager

Note: pytest is not installed in this environment.